### PR TITLE
Fix compilation warning

### DIFF
--- a/m20/Core/Src/afsk.c
+++ b/m20/Core/Src/afsk.c
@@ -105,6 +105,8 @@ static bool get_next_bit()
     { // N3 octet sync section
         return (AFSK_SYNC_FLAG >> (7 - (bit_pos % 8))) & 1;
     }
+    
+    return 0; // Default return value for unexpected cases
 }
 
 void AFSK_timer_handler()


### PR DESCRIPTION
Fixes

```
Core/Src/afsk.c: In function 'get_next_bit':
Core/Src/afsk.c:108:1: warning: control reaches end of non-void function [-Wreturn-type]
  108 | }
      | ^
```