### PR TITLE
Remove APRS time field

### DIFF
--- a/m20/Core/Inc/aprs.h
+++ b/m20/Core/Inc/aprs.h
@@ -9,7 +9,7 @@
 #define APRS_PROTOCOL_ID 0xf0
 #define APRS_SPACE_SYMBOL 0x20
 
-#define APRS_INFO_DATA_LEN 30   // info field data length
+#define APRS_INFO_DATA_LEN 23   // info field data length
 #define APRS_MAX_TELEM_LEN 38   // comment telemetry max length
 #define APRS_AX25_FORMAT_LEN 32 // AX.25 additional length: 7 bytes * 4 fields (source, destination, path 1, path 2) + 2 control bytes
 

--- a/m20/Core/Inc/aprs.h
+++ b/m20/Core/Inc/aprs.h
@@ -9,7 +9,12 @@
 #define APRS_PROTOCOL_ID 0xf0
 #define APRS_SPACE_SYMBOL 0x20
 
+#if APRS_TIMESTAMP
+#define APRS_INFO_DATA_LEN 30   // info field data length (with timestamp)
+#else
 #define APRS_INFO_DATA_LEN 23   // info field data length
+#endif
+
 #define APRS_MAX_TELEM_LEN 38   // comment telemetry max length
 #define APRS_AX25_FORMAT_LEN 32 // AX.25 additional length: 7 bytes * 4 fields (source, destination, path 1, path 2) + 2 control bytes
 

--- a/m20/Core/Inc/config.h
+++ b/m20/Core/Inc/config.h
@@ -40,6 +40,8 @@ const static float QRG_AFSK[] = {
 #define APRS_PATH "WIDE2" // Path, max 6 digits according to https://www.aprs.org/balloons.html
 #define APRS_PATH_SSID 1  // Path SSID
 
+#define APRS_TIMESTAMP 0 // Disable APRS timestanp sending by default, it has some werid issues on the map.
+
 #define APRS_SYMBOL "/O" // baloon symbol, all symbols: https://www.aprs.org/symbols.html, needs to be /O for showing on Sondehub
 
 #define APRS_COMMENT_TELEMETRY 1 // Telemetry in coment field

--- a/m20/Core/Src/aprs.c
+++ b/m20/Core/Src/aprs.c
@@ -162,18 +162,7 @@ uint8_t encode_APRS_packet(APRSPacket Packet, char* buff) {
 	char info_field[APRS_MAX_INFO_LEN];
 	uint8_t pos = 0;
 
-	info_field[pos++] = '@'; // data type identifier
-
-	info_field[pos++] = Packet.Hours / 10 + '0';
-	info_field[pos++] = Packet.Hours % 10 + '0'; // Hours
-
-	info_field[pos++] = Packet.Minutes / 10 + '0';
-	info_field[pos++] = Packet.Minutes % 10 + '0'; // Minutes
-
-	info_field[pos++] = Packet.Seconds / 10 + '0';
-	info_field[pos++] = Packet.Seconds % 10 + '0'; // Seconds
-
-	info_field[pos++] = 'z'; // Zullu time
+	info_field[pos++] = '!'; // data type identifier
 
 	info_field[pos++] = APRS_SYMBOL[0]; // Symbol table ID
 

--- a/m20/Core/Src/aprs.c
+++ b/m20/Core/Src/aprs.c
@@ -162,7 +162,22 @@ uint8_t encode_APRS_packet(APRSPacket Packet, char* buff) {
 	char info_field[APRS_MAX_INFO_LEN];
 	uint8_t pos = 0;
 
-	info_field[pos++] = '!'; // data type identifier
+#if APRS_TIMESTAMP
+	info_field[pos++] = '@'; // data type identifier (with timestamp)
+
+	info_field[pos++] = Packet.Hours / 10 + '0';
+	info_field[pos++] = Packet.Hours % 10 + '0'; // Hours
+
+	info_field[pos++] = Packet.Minutes / 10 + '0';
+	info_field[pos++] = Packet.Minutes % 10 + '0'; // Minutes
+
+	info_field[pos++] = Packet.Seconds / 10 + '0';
+	info_field[pos++] = Packet.Seconds % 10 + '0'; // Seconds
+
+	info_field[pos++] = 'z'; // Zullu time
+#else
+	info_field[pos++] = '!'; // data type identifier (without timestamp)
+#endif
 
 	info_field[pos++] = APRS_SYMBOL[0]; // Symbol table ID
 


### PR DESCRIPTION
Removed APRS time field (changed frame type from`@` to `!`) to fix problems with routing in network. Packets are sometimes sent multiple times, even hours after reception. It appears that without the time field the problem does not appear, since other HAB firmwares send the `!` frame with no problems.

This needs testing and checking how the frames look in APRS-IS network.